### PR TITLE
Update cartalk1.py

### DIFF
--- a/code/cartalk1.py
+++ b/code/cartalk1.py
@@ -28,8 +28,8 @@ def is_triple_double(word):
                 return True
             i = i + 2
         else:
+            i = i + 1 - 2*count
             count = 0
-            i = i + 1
     return False
 
 


### PR DESCRIPTION
Prior implementation does not skip backwards after a failed partial match.

For example, prior implementation does not accept theoretical words:
aaabbccd
aaaaabbc